### PR TITLE
Support new docker beta which isn't on 192.168.99.100

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,27 @@
 start:
-ifeq ("${DOCKER_MACHINE_NAME}", "")
+ifndef $(shell pinata --version 2> /dev/null)
+	@echo "---- YOU MAY BE RUNNING BETA DOCKER ----"
+	@echo 'Your results may vary.'
+	@echo "-------------------------------------"
+	@echo ""
+	@echo "Sleeping 10 seconds...."
+	@sleep 10
+else ifeq ("${DOCKER_MACHINE_NAME}", "")
 	@echo "---- YOUR DOCKER MACHINE IS NOT INITIALIZED ----"
 	@echo 'Please run "eval $$(docker-machine env default)"'
 	@echo "------------------------------------------------"
-else ifeq ($(shell docker-machine ip ${DOCKER_MACHINE_NAME}),192.168.99.100)
-	docker-compose stop
-	docker-compose rm -f
-	docker-compose build
-	docker-compose up
-else
+	@exit 1
+else ifneq ($(shell docker-machine ip ${DOCKER_MACHINE_NAME}),192.168.99.100)
 	@echo "---- YOUR DOCKER IP IS WRONG ----"
 	@echo "Your docker IP should be 192.168.99.100, but it is $(shell docker-machine ip ${DOCKER_MACHINE_NAME})"
 	@echo "See: https://github.com/articulate/tugboat/blob/master/README.md#tugboat-says-my-ip-doesnt-match-19216899100"
 	@echo "---------------------------------"
+	@exit 1
 endif
+	docker-compose stop
+	docker-compose rm -f
+	docker-compose build
+	docker-compose up
 
 stop:
 	docker-compose stop

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 start:
-ifndef $(shell pinata --version 2> /dev/null)
+ifneq (, $(shell which pinata))
 	@echo "---- YOU MAY BE RUNNING BETA DOCKER ----"
 	@echo 'Your results may vary.'
 	@echo "-------------------------------------"

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ Tugboat relies on the fact that your VM is running on the default IP. Some situa
 1. Reboot your machine (not the VM).
 2. Run `docker-machine stop default`, ensure all virtualbox VMs are stopped, all virtualbox processes are stopped (including the GUI), and then run run `docker-machine start default`.  If this doesn't work, see (1).
 
+## Notes on Docker Beta for Mac/Windows
+
+Docker beta uses the IP 127.0.0.1 instead of 192.168.99.100.  So you will need to use the hostnames `beta.tugboat.tld` which maps to 127.0.0.1.
+
+See section `Custom Configuration` above.
+
 ## Contributing
 
 1. Fork it ( https://github.com/articulate/tugboat/fork )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,11 @@ consul:
   labels:
     - "SERVICE_8500_NAME=consul"
     - "SERVICE_8500_TAGS=load-balance"
+  restart: always
 
 registrator:
   image: gliderlabs/registrator:latest
-  command: -ip 192.168.99.100 consul://consul:8500
+  command: -internal consul://consul:8500
   volumes:
     - "/var/run/docker.sock:/tmp/docker.sock"
   links:


### PR DESCRIPTION
This fixes up tugboat to no longer be dependant on the IP being `192.168.99.100`. This also adds some additional hostnames for the beta to the README.
