### PR TITLE
add support for ip aliasing in linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 UNAME := $(shell uname)
-DEVICE := $(shell netstat -r | grep ^default | tr ' ' '\n' | tail -n1)
+
+ifeq ($(UNAME), Linux)
+DEVICE := $(shell netstat -rn -A inet | grep ^0.0.0.0 | tr ' ' '\n' | tail -n1)
+else
+DEVICE := $(shell netstat -rn -f inet | grep ^default | tr ' ' '\n' | tail -n1)
+endif
 
 start:
 	docker-compose stop
@@ -10,7 +15,7 @@ ifneq (, $(shell docker info | grep "provider=virtualbox"))
 	@echo "---- YOU ARE RUNNING DOCKER TOOLBOX ----"
 	TUGBOAT_IP=192.168.99.100 docker-compose up
 else
-	@echo "---- YOU ARE RUNNING DOCKER FOR MAC/WINDOWS/LINUX ----"
+	@echo "---- YOU ARE RUNNING DOCKER FOR MAC/LINUX ----"
 ifneq (, $(shell ifconfig | grep "192.168.65.1"))
 	@echo "---- IP FOUND ----"
 else
@@ -18,8 +23,8 @@ ifeq ($(UNAME), Linux)
 	@echo "---- LINUX, ADDING IP ALIAS ----"
 	sudo ifconfig $(DEVICE):tugboat 192.168.65.1 up
 else
-	@echo "---- MAC/WINDOWS, ADDING IP ALIAS ----"
-	sudo ifconfig en0 alias 192.168.65.1 255.255.255.0
+	@echo "---- MAC, ADDING IP ALIAS ----"
+	sudo ifconfig $(DEVICE) alias 192.168.65.1 255.255.255.0
 endif
 endif
 	TUGBOAT_IP=192.168.65.1 docker-compose up
@@ -30,5 +35,5 @@ stop:
 ifeq ($(UNAME), Linux)
 	sudo ifconfig $(DEVICE):tugboat 192.168.65.1 down
 else
-	sudo ifconfig en0 -alias 192.168.65.1
+	sudo ifconfig $(DEVICE) -alias 192.168.65.1
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+UNAME := $(shell uname)
+DEVICE := $(shell netstat -r | grep ^default | tr ' ' '\n' | tail -n1)
+
 start:
 	docker-compose stop
 	docker-compose rm -f
@@ -7,15 +10,25 @@ ifneq (, $(shell docker info | grep "provider=virtualbox"))
 	@echo "---- YOU ARE RUNNING DOCKER TOOLBOX ----"
 	TUGBOAT_IP=192.168.99.100 docker-compose up
 else
-	@echo "---- YOU ARE RUNNING DOCKER FOR MAC/WINDOWS ----"
+	@echo "---- YOU ARE RUNNING DOCKER FOR MAC/WINDOWS/LINUX ----"
 ifneq (, $(shell ifconfig | grep "192.168.65.1"))
 	@echo "---- IP FOUND ----"
 else
-	@echo "---- IP NOT FOUND, ADDING ----"
+ifeq ($(UNAME), Linux)
+	@echo "---- LINUX, ADDING IP ALIAS ----"
+	sudo ifconfig $(DEVICE):tugboat 192.168.65.1 up
+else
+	@echo "---- MAC/WINDOWS, ADDING IP ALIAS ----"
 	sudo ifconfig en0 alias 192.168.65.1 255.255.255.0
+endif
 endif
 	TUGBOAT_IP=192.168.65.1 docker-compose up
 endif
 
 stop:
 	docker-compose stop
+ifeq ($(UNAME), Linux)
+	sudo ifconfig $(DEVICE):tugboat 192.168.65.1 down
+else
+	sudo ifconfig en0 -alias 192.168.65.1
+endif

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains a fabio reverse proxy, consul, and registrator.  When used together, they can create dynamic virtual host for any web container you launch.
 
-This project requires that you are using the Docker for Windows / Mac.  It will not work on linux (unless you manually set an interface alias with the IP 192.168.65.1).
+This project requires that you are using Docker for Windows, Mac, or Linux. At the time of this writing, Docker Toolbox is not available for Linux, but docker-compose is available to download [here](https://docs.docker.com/compose/install/).
 
 This means every new container (when lightly configured) you launch, will have a custom hostname you can pull up in your browser.
 
@@ -64,14 +64,6 @@ We own and have wildcard DNS set up for the following domains:
 Are you at company where you want all of your devs to use the same custom configuration?  Well we are too, so we have you sorted there as well!
 
 Head on over to [Tugboat Bootstrapper](https://github.com/articulate/tugboat-bootstrapper) to learn how to create a repo with static configs
-
-## What if I'm running linux?
-
-Well, we don't officially support linux as our setup makes an assumption you are using the Docker Toolbox.  However you can still get it working.  You either need to create a virtual network interface bound on `192.168.99.100` or edit this project to change it to use your host IP and the using a custom domain which wildcards to your custom IP.  This is out of the scope of this tool, but its still possible.
-
-A virtual network interface is your best option.
-
-If you know of a good way to adapt this tool to work with linux, feel free to submit a pull request.
 
 ## Troubleshooting
 


### PR DESCRIPTION
to add linux support, we use `netstat -r` to find the device associated with the default gateway and create our ip alias for that particular device. I also added to the stop recipe to remove the ip alias.

I believe `netstat -r` is also available on osx and the output is similar to the linux output so I chose that method to get the default gateway device in an attempt to be cross platform. I do not believe the output is similar on windows so this may ultimately not be the best method to figure out the default gateway device.