### PR TITLE
Don't listen on everything, allow fabio to 404

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - "FABIO_UI_TITLE=Tugboat Services"
       - "FABIO_UI_COLOR=blue"
       - "REGISTRY_CONSUL_ADDR=consul:8500"
-      - "REGISTRY_CONSUL_REGISTER_TAGS=urlprefix-fabio.*/,urlprefix-/"
+      - "REGISTRY_CONSUL_REGISTER_TAGS=urlprefix-fabio.*/"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
So that when you're using tugboat to mount API endpoints, you don't have weird behaviours like errors regarding parsing of HTML (when your API should be json only).