### PR TITLE
Dynamic consul vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ You need to add the following 5 lines to your service you want load balanced to 
 ports:
   - 3000 #ensure this is the correct port your service exposes
 labels:
-  - "SERVICE_3000_NAME=awesome-service" #adjust the port number here too, if needed
-  - "SERVICE_3000_TAGS=urlprefix-awesome-service.*/"
+  SERVICE_3000_NAME: awesome-service #adjust the port number here too, if needed
+  SERVICE_3000_TAGS: urlprefix-awesome-service.*/
 ```
 
 **Note:** the `ports` line should NOT look like `3000:3000`. It should be a single port number only.  This allows docker to assign a RANDOM port to bind to on the host.  Consul / Registrator / fabio will handle this random port without issue. This prevents you from experiencing port conflicts!
@@ -66,6 +66,26 @@ We own and have wildcard DNS set up for the following domains:
 Are you at company where you want all of your devs to use the same custom configuration?  Well we are too, so we have you sorted there as well!
 
 Head on over to [Tugboat Bootstrapper](https://github.com/articulate/tugboat-bootstrapper) to learn how to create a repo with static configs
+
+## Dynamic Consul Key/Value pairs
+
+Tugboat supports dynamically setting consul key/values into its consul when you start a container.
+
+Add this TAG when starting your docker container: `consul-key:[consul path]:[value]`
+
+For example: `consul-key:apps/my-service/env_vars/SOME_ENV_VAR:some-value`
+
+That will set a key in `apps/my-service/env_vars/SOME_ENV_VAR` with the value of `some-value`
+
+A complete labels section in your `docker-compose.yml` would look like:
+
+```
+labels:
+  SERVICE_3000_NAME: awesome-service #adjust the port number here too, if needed
+  SERVICE_3000_TAGS: >
+    urlprefix-awesome-service.*/,
+    consul-key:apps/my-service/env_vars/SOME_ENV_VAR:some-value
+```
 
 ## Troubleshooting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,16 @@ services:
     restart: always
     depends_on:
       - consul
+
+  consul-template:
+    image: hashicorp/consul-template:alpine
+    command: "-template '/register-hosts.ctmpl:/tmp/register-hosts.sh:/bin/sh /tmp/register-hosts.sh'"
+    volumes:
+      - "./register-hosts.ctmpl:/register-hosts.ctmpl"
+    dns_search: ""
+    environment:
+      CONSUL_HTTP_ADDR: "http://consul:8500"
+    restart: always
+    depends_on:
+      - consul
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       SERVICE_8500_CHECK_TCP: "true"
       SERVICE_8500_CHECK_INTERVAL: "15s"
       SERVICE_8500_NAME: "consul"
-      SERVICE_8500_TAGS: "urlprefix-consul.*/"
+      SERVICE_8500_TAGS: "urlprefix-consul-tugboat.*/"
     restart: always
 
   registrator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     labels:
       SERVICE_8500_CHECK_TCP: "true"
       SERVICE_8500_CHECK_INTERVAL: "15s"
-      SERVICE_8500_NAME: "consul"
+      SERVICE_8500_NAME: "consul-tugboat"
       SERVICE_8500_TAGS: "urlprefix-consul-tugboat.*/"
     restart: always
 

--- a/register-hosts.ctmpl
+++ b/register-hosts.ctmpl
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+curl -X DELETE "${CONSUL_HTTP_ADDR}/v1/kv?recurse=true"
+{{ range services }}
+{{ range service .Name }}
+{{ range $tag := .Tags }}
+{{ if $tag | regexMatch "consul-key:(.*?):(.*?)" }}
+curl -X PUT ${CONSUL_HTTP_ADDR}/v1/kv/{{ $tag | regexReplaceAll "consul-key:(.*?):.*" "$1" }} -d '{{ $tag | regexReplaceAll "consul-key:.*?:(.*)" "$1" }}'
+{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Adds support to add Consul key value pairs when a container starts up.  Allows you to use those variables for things like environment variable overrides based on a container starting up.