### PR TITLE
Set COMPOSE_CONVERT_WINDOWS_PATHS environment variable on Windows

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -7,6 +7,10 @@ $p.ExitCode
 
 Set-Item Env:TUGBOAT_IP "10.156.156.1"
 
+# This addresses a regression in Docker 18.03.0-ce
+# See https://github.com/docker/for-win/issues/1829
+Set-Item Env:COMPOSE_CONVERT_WINDOWS_PATHS 1
+
 docker-compose stop
 docker-compose rm -f
 docker-compose build


### PR DESCRIPTION
Docker 18.03.0 and later have a regression which causes a "mount denied - <path> is not a valid Windows path" error when attempting to mount /var/run/docker.sock via docker-compose.yml. As documented in https://github.com/docker/for-win/issues/1829, setting the `COMPOSE_CONVERT_WINDOWS_PATHS` environment variable to a truthy value works around this issue.

@tecnobrat Please review.